### PR TITLE
解决repush=-1时客户端停止推流后一直推流的问题

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,6 +100,7 @@ func NewRTMPClient(addr string) (client *NetConnection, err error) {
 type RTMPPusher struct {
 	RTMPSender
 	engine.Pusher
+	isClientStop bool
 }
 
 func (pusher *RTMPPusher) Connect() (err error) {
@@ -155,6 +156,17 @@ func (pusher *RTMPPusher) Push() error {
 			}
 		}
 	}
+}
+
+func (pusher *RTMPPusher) OnEvent(event any) {
+	switch event.(type) {
+	case engine.SEclose:
+		pusher.isClientStop = true
+	}
+}
+
+func (pusher *RTMPPusher) IsShutdown() bool {
+	return pusher.isClientStop
 }
 
 type RTMPPuller struct {


### PR DESCRIPTION
修改前，repush = -1 时，客户端停止后，还是一直重试
![abc9cfed7f7b95020c6268521ae652f](https://user-images.githubusercontent.com/1883728/221389135-26dd6ad0-3022-4c7f-90dc-0b953e85cb97.png)

修改后，会stop push shutdown
![bc338afce5100eec5ac8105dfb8e334](https://user-images.githubusercontent.com/1883728/221389153-87595e94-cf35-4d97-9e9a-83a1933e1b3d.png)
